### PR TITLE
Release 0.7.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ line-length = 120
 
 [tool.poetry]
 name = "bioexperiment-suite"
-version = "0.6.1"
+version = "0.7.0"
 description = "Python toolbox for managing biological experiment devices via the lab_devices_client HTTP service."
 license = "MIT"
 authors = ["Denis Khamitov <hamitov.97@mail.ru>"]


### PR DESCRIPTION
## Summary

Bumps version to 0.7.0 for release. Includes the username-based discovery feature merged in #3:

- `LabDevicesClient(user="...")` resolves lab machines by name via the lab-bridge roster endpoint
- `LabDevicesClient.list_registered_users()` / `list_active_users()` classmethods
- New `ClientLookupError` hierarchy distinct from `LabDevicesError`
- Fully backwards compatible: existing `LabDevicesClient(port=...)` callers unchanged

Minor bump (0.6.1 → 0.7.0) per semver: backwards-compatible feature addition.

## Test plan

- [x] All 96 tests pass on main
- [ ] After merge: tag `v0.7.0`, build, publish to PyPI

🤖 Generated with [Claude Code](https://claude.com/claude-code)