### PR TITLE
Document username-based discovery in README and examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,30 @@ Ensure you have the following installed on your machine:
 
 ## Usage
 
+### Connecting to your lab machine
+
+Lab machines are addressed by name. The client looks the name up in the lab-bridge roster and opens an HTTP session to that machine's `lab_devices_client` service:
+
+```python
+from bioexperiment_suite.interfaces import LabDevicesClient
+
+with LabDevicesClient(user="khamit_desktop") as client:
+    devices = client.discover()
+    (pump1, pump2) = devices.pumps
+    (densitometer,) = devices.densitometers
+```
+
+If you don't know which name to use, ask the bridge:
+
+```python
+LabDevicesClient.list_registered_users()  # every machine the bridge knows about
+LabDevicesClient.list_active_users()      # only the ones currently answering
+```
+
+Lookups go through `http://siteapp:8000/api/clients/` by default; override with the `LAB_DEVICES_DISCOVERY_URL` environment variable or the `discovery_url=` keyword argument when running outside the standard `labnet` setup.
+
+### Building an experiment
+
 For comprehensive usage examples, please see the [examples](examples) directory.
 
 ## License

--- a/examples/experiment_example.ipynb
+++ b/examples/experiment_example.ipynb
@@ -10,7 +10,7 @@
     "from bioexperiment_suite.experiment import Experiment, Condition\n",
     "from bioexperiment_suite.interfaces import LabDevicesClient\n",
     "\n",
-    "LAB_DEVICES_PORT = 9001  # Per-lab-machine chisel-tunnel port"
+    "LAB_MACHINE = \"khamit_desktop\"  # Name from LabDevicesClient.list_registered_users()"
    ]
   },
   {
@@ -72,7 +72,7 @@
    "outputs": [],
    "source": [
     "# Connect to the lab devices service and discover devices\n",
-    "client = LabDevicesClient(port=LAB_DEVICES_PORT)\n",
+    "client = LabDevicesClient(user=LAB_MACHINE)\n",
     "devices = client.discover()\n",
     "\n",
     "pumps = devices.pumps\n",

--- a/examples/experiment_example.py
+++ b/examples/experiment_example.py
@@ -10,7 +10,7 @@ POURED_OUT_VOLUME_ML = 2  # Volume of solution poured out in mL
 INFUSED_VOLUME_ML = 1  # Volume of solution infused in mL
 FLOW_RATE_ML_PER_MINUTE = 3  # Flow rate of the pump in mL/min
 
-LAB_DEVICES_PORT = 9001  # Per-lab-machine chisel-tunnel port
+LAB_MACHINE = "khamit_desktop"  # Name from LabDevicesClient.list_registered_users()
 
 # Ensure intervals are valid
 assert (
@@ -29,7 +29,7 @@ n_measurements_per_solution_refresh = (
 )
 
 # Connect to the lab devices service and discover devices
-client = LabDevicesClient(port=LAB_DEVICES_PORT)
+client = LabDevicesClient(user=LAB_MACHINE)
 devices = client.discover()
 
 # Unpack discovered devices

--- a/examples/three_pumps_experiment.py
+++ b/examples/three_pumps_experiment.py
@@ -21,7 +21,7 @@ PUMP_DRUG_VOLUME_ML = 2
 
 OPTICAL_DENSITY_THRESHOLD = 0.5
 
-LAB_DEVICES_PORT = 9001  # Per-lab-machine chisel-tunnel port
+LAB_MACHINE = "khamit_desktop"  # Name from LabDevicesClient.list_registered_users()
 
 # Define measurements
 OPTICAL_DENSITY = "optical_density"
@@ -51,7 +51,7 @@ delay_time = (PUMP_OUT_VOLUME_ML / FLOW_RATE_ML_PER_MINUTE) * 60 + 1 + INWARDS_P
 
 
 # Connect to the lab devices service and discover devices
-client = LabDevicesClient(port=LAB_DEVICES_PORT)
+client = LabDevicesClient(user=LAB_MACHINE)
 devices = client.discover()
 
 (densitometer,) = devices.densitometers  # Suppose we have one densitometer


### PR DESCRIPTION
## Summary
- Add a *Connecting to your lab machine* section to the README showing `LabDevicesClient(user=...)`, the `list_registered_users()` / `list_active_users()` classmethods, and the `LAB_DEVICES_DISCOVERY_URL` / `discovery_url=` override.
- Switch `examples/experiment_example.py`, `examples/three_pumps_experiment.py`, and `examples/experiment_example.ipynb` from the old `LAB_DEVICES_PORT` / `LabDevicesClient(port=...)` pattern to `LAB_MACHINE` / `LabDevicesClient(user=...)`, matching the discovery flow introduced in #3.

The `port=` constructor argument still works for backwards compatibility but is no longer surfaced in any user-facing material.

## Test plan
- [ ] Render the README on GitHub and confirm the new section reads cleanly.
- [ ] Open `examples/experiment_example.ipynb` in Jupyter and confirm cells 0 and 3 show the new `user=` flow.
- [ ] Import each example script (`python -c "import ast; ast.parse(open('examples/experiment_example.py').read())"` etc.) to confirm they still parse.

🤖 Generated with [Claude Code](https://claude.com/claude-code)